### PR TITLE
OverlayFS bug workaround

### DIFF
--- a/cr-service.c
+++ b/cr-service.c
@@ -315,6 +315,9 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	if (req->has_shell_job)
 		opts.shell_job = req->shell_job;
 
+	if (req->has_overlayfs)
+		opts.overlayfs = req->overlayfs;
+
 	if (req->has_file_locks)
 		opts.handle_file_locks = req->file_locks;
 

--- a/crtools.c
+++ b/crtools.c
@@ -235,6 +235,7 @@ int main(int argc, char *argv[], char *envp[])
 		{ "enable-fs",			required_argument,	0, 1065 },
 		{ "enable-external-sharing", 	no_argument, 		0, 1066 },
 		{ "enable-external-masters", 	no_argument, 		0, 1067 },
+		{ "overlayfs",			no_argument,		0, 1068 },
 		{ },
 	};
 
@@ -464,6 +465,9 @@ int main(int argc, char *argv[], char *envp[])
 			break;
 		case 1067:
 			opts.enable_external_masters = true;
+			break;
+		case 1068:
+			opts.overlayfs = true;
 			break;
 		case 'M':
 			{

--- a/files.c
+++ b/files.c
@@ -30,6 +30,7 @@
 #include "eventfd.h"
 #include "eventpoll.h"
 #include "fsnotify.h"
+#include "mount.h"
 #include "signalfd.h"
 #include "namespaces.h"
 #include "tun.h"
@@ -157,6 +158,45 @@ void show_saved_files(void)
 }
 
 /*
+ * Workaround for the OverlayFS bug present before Kernel 4.2
+ *
+ * When a process has a file open in an OverlayFS directory,
+ * the information in /proc/<pid>/fd/<fd> and /proc/<pid>/fdinfo/<fd>
+ * is wrong, so, if --overlayfs is specified, we grab that information
+ * from the mountinfo table instead.
+ *
+ * This is done every time fill_fdlink is called. See lookup_overlayfs
+ * for more details.
+ */
+static int fixup_overlayfs(struct fd_parms *p, struct fd_link *link)
+{
+	struct mount_info *m;
+
+	if (!link)
+		return 0;
+
+	m = lookup_overlayfs(link->name, p->stat.st_dev, p->stat.st_ino, p->mnt_id);
+	if (!m)
+		return 0;
+
+	p->mnt_id = m->mnt_id;
+
+	/* Stores the correct file path in p->link->name */
+	if (strcmp("./", m->mountpoint) != 0) {
+		char buf[PATH_MAX];
+		int n;
+
+		strncpy(buf, link->name, PATH_MAX);
+		n = snprintf(link->name, PATH_MAX, "%s/%s", m->mountpoint, buf + 2);
+		if (n >= PATH_MAX) {
+			pr_err("Not enough space to replace %s\n", buf);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/*
  * The gen_id thing is used to optimize the comparison of shared files.
  * If two files have different gen_ids, then they are different for sure.
  * If it matches, we don't know it and have to call sys_kcmp().
@@ -206,6 +246,10 @@ int fill_fdlink(int lfd, const struct fd_parms *p, struct fd_link *link)
 	}
 
 	link->len = len + 1;
+
+	if (opts.overlayfs)
+		if (fixup_overlayfs((struct fd_parms *)p, link) < 0)
+			return -1;
 	return 0;
 }
 

--- a/include/cr_options.h
+++ b/include/cr_options.h
@@ -79,6 +79,7 @@ struct cr_options {
 	bool			enable_external_sharing;
 	bool			enable_external_masters;
 	bool			aufs;		/* auto-deteced, not via cli */
+	bool			overlayfs;
 };
 
 extern struct cr_options opts;

--- a/include/mount.h
+++ b/include/mount.h
@@ -22,6 +22,8 @@ extern int prepare_mnt_ns(void);
 extern int pivot_root(const char *new_root, const char *put_old);
 
 struct mount_info;
+struct mount_info *lookup_overlayfs(char *rpath, unsigned int s_dev,
+				unsigned int st_ino, unsigned int mnt_id);
 extern struct mount_info *lookup_mnt_id(unsigned int id);
 extern struct mount_info *lookup_mnt_sdev(unsigned int s_dev);
 

--- a/lib/criu.c
+++ b/lib/criu.c
@@ -309,6 +309,17 @@ void criu_set_evasive_devices(bool evasive_devices)
 	criu_local_set_evasive_devices(global_opts, evasive_devices);
 }
 
+void criu_local_set_overlayfs(criu_opts *opts, bool overlayfs)
+{
+	opts->rpc->has_overlayfs	= true;
+	opts->rpc->overlayfs		= overlayfs;
+}
+
+void criu_set_overlayfs(bool overlayfs)
+{
+	criu_local_set_overlayfs(global_opts, overlayfs);
+}
+
 void criu_local_set_shell_job(criu_opts *opts, bool shell_job)
 {
 	opts->rpc->has_shell_job	= true;

--- a/protobuf/mnt.proto
+++ b/protobuf/mnt.proto
@@ -18,6 +18,7 @@ enum fstype {
 	MQUEUE			= 14;
 	FUSE			= 15;
 	AUTO			= 16;
+	OVERLAYFS		= 17;
 };
 
 message mnt_entry {

--- a/protobuf/rpc.proto
+++ b/protobuf/rpc.proto
@@ -74,6 +74,8 @@ message criu_opts {
 	repeated string			enable_fs	= 32;
 
 	repeated unix_sk                unix_sk_ino     = 33;
+
+	optional bool			overlayfs	= 34;
 }
 
 message criu_dump_resp {

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ all:
 
 .PHONY: all
 
-TESTS = unix-callback mem-snap rpc libcriu mounts/ext security pipes crit socketpairs
+TESTS = unix-callback mem-snap rpc libcriu mounts/ext security pipes crit socketpairs overlayfs
 
 other: .FORCE
 	for t in $(TESTS); do			\

--- a/test/overlayfs/Makefile
+++ b/test/overlayfs/Makefile
@@ -1,0 +1,6 @@
+run:
+	./run.sh
+
+clean:
+	umount -f overlay_test/z
+	rm -rf overlay_test

--- a/test/overlayfs/run.sh
+++ b/test/overlayfs/run.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eu
+
+CRIU=../../../criu
+
+setup() {
+	setup_mount
+	sleep 10 3>z/file &
+	PROC_PID=$!
+	echo "PROC_PID=$PROC_PID"
+	sleep 1
+}
+
+setup_mount() {
+	mkdir -p overlay_test
+	cd overlay_test
+	mkdir -p a b c z checkpoint
+	mount -t overlay -o lowerdir=a,upperdir=b,workdir=c overlayfs z
+}
+
+check_criu() {
+	echo "Dumping $PROC_PID..."
+	if ! $CRIU dump -D checkpoint --overlayfs --shell-job -t "${PROC_PID}"; then
+		echo "ERROR! dump failed"
+		return 1
+	fi
+
+	echo "Restoring..."
+	if ! $CRIU restore -d -D checkpoint --shell-job; then
+		echo "ERROR! restore failed"
+		return 1
+	fi
+	return 0
+}
+
+cleanup() {
+	kill -INT "${PROC_PID}" > /dev/null 2>&1
+	umount z
+	cd "${ORIG_WD}"
+	rm -rf overlay_test
+}
+
+main() {
+	ORIG_WD=$(pwd)
+	setup
+
+	check_criu || {
+		cleanup
+		exit 1
+	}
+
+	cleanup
+	echo "OverlayFS C/R successful."
+	exit 0
+}
+
+main


### PR DESCRIPTION
This PR enables the --overlayfs flag in CRIU which compensates for the OverlayFS bug in the Linux Kernel before version 4.2 (more about the bug at http://criu.org/Docker). More detailed information can be found in the comments below.