### PR TITLE
Remove multiple command validation as cpuinfo requires it

### DIFF
--- a/crtools.c
+++ b/crtools.c
@@ -557,9 +557,6 @@ int main(int argc, char *argv[], char *envp[])
 			return 1;
 		memcpy(opts.exec_cmd, &argv[optind + 1], (argc - optind - 1) * sizeof(char *));
 		opts.exec_cmd[argc - optind - 1] = NULL;
-	} else if (optind + 1 != argc) {
-		pr_err("Unable to handle more than one command\n");
-		goto usage;
 	}
 
 	/* We must not open imgs dir, if service is called */


### PR DESCRIPTION
`criu cpuinfo [dump | check]` can't be used through the command line as this validation kicks in. 
Other commands will fail due to required arguments so I believe it's not necessary anymore.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>