### PR TITLE
Fix 'mnt_path' may be used uninitialized in this function

### DIFF
--- a/mount.c
+++ b/mount.c
@@ -2280,7 +2280,7 @@ static int do_bind_mount(struct mount_info *mi)
 	int exit_code = -1;
 	bool shared = false;
 	bool master = false;
-	char *mnt_path;
+	char *mnt_path = NULL;
 	struct stat st;
 	bool umount_mnt_path = false;
 


### PR DESCRIPTION
I try to build criu in my environment, but error occurred.

### error
```
cc1: warnings being treated as errors
mount.c: In function 'do_bind_mount':
mount.c:2283: error: 'mnt_path' may be used uninitialized in this function
make[1]: *** [mount.o] Error 1
make[1]: Leaving directory `/home/vagrant/criu'
make: *** [built-in.o] Error 2
```

### my environment

- gcc
```
$ gcc -v
Using built-in specs.
Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-languages=c,c++,objc,obj-c++,java,fortran,ada --enable-java-awt=gtk --disable-dssi --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-1.5.0.0/jre --enable-libgcj-multifile --enable-java-maintainer-mode --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --disable-libjava-multilib --with-ppl --with-cloog --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
gcc version 4.4.7 20120313 (Red Hat 4.4.7-3) (GCC) 
```

- kernel version

```
$ uname -a
Linux users501.phy.lolipop.pb 4.3.3 #1 SMP Mon Dec 21 02:38:16 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
```

- error

```
mount.c:2283: error: 'mnt_path' may be used uninitialized in this function
```