### PR TITLE
Add script to install required packages in Debian

### DIFF
--- a/contrib/debian/dev-packages.lst
+++ b/contrib/debian/dev-packages.lst
@@ -1,0 +1,18 @@
+# Required packages for development in Debian
+build-essential
+libprotobuf-dev
+libprotobuf-c0-dev
+protobuf-c-compiler
+protobuf-compiler
+python-protobuf
+
+# Extra packages, required for testing and building other tools
+pkg-config
+libnl-3-dev
+python-ipaddr
+libbsd0
+libbsd-dev
+iproute2
+libcap-dev
+libaio-dev
+python-yaml

--- a/scripts/install-debian-pkgs.sh
+++ b/scripts/install-debian-pkgs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Install required packages for development environment in Debian Distro
+
+REQ_PKGS=${REQ_PKGS:=contrib/debian/dev-packages.lst}
+
+help_msg="Install required packages for development environment in Debian Distro
+Usage:
+	scripts/install-debian-pkgs.sh"
+
+function print_help()
+{
+	exec echo -e "$help_msg"
+}
+
+function process()
+{
+	sudo apt-get update
+	sudo apt-get install -yq $( sed 's/\#.*$//' ${REQ_PKGS} )
+}
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	print_help
+else
+	process
+fi


### PR DESCRIPTION
contrib/debian/dev-packages.lst:
* List of required packages for Debian development environment

scripts/install-debian-pkgs.sh:
* A simple bash script instaling the required Debian packages

Signed-off-by: Tuan T. Pham <tuan@vt.edu>