### PR TITLE
include sys/sysmacros.h for minor/major/makedev funcs

### DIFF
--- a/criu/file-lock.c
+++ b/criu/file-lock.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include "cr_options.h"
 #include "imgset.h"

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/statfs.h>
+#include <sys/sysmacros.h>
 #include <dirent.h>
 
 #include "int.h"

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -7,6 +7,7 @@
 #include <sys/mman.h>
 #include <errno.h>
 #include <sys/syscall.h>
+#include <sys/sysmacros.h>
 
 #include "int.h"
 #include "log.h"

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <linux/fs.h>
+#include <sys/sysmacros.h>
 
 #include "types.h"
 #include "common/list.h"

--- a/test/zdtm/lib/fs.h
+++ b/test/zdtm/lib/fs.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include <limits.h>
 

--- a/test/zdtm/static/console.c
+++ b/test/zdtm/static/console.c
@@ -8,6 +8,7 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "zdtmtst.h"
 


### PR DESCRIPTION
Since glibc is moving away from implicitly including sys/sysmacros.h
all the time via sys/types.h, include the header directly in more
places.  This seems to cover most makedev/major/minor usage.

Signed-off-by: Yixun Lan <dlan@gentoo.org>
Signed-off-by: Mike Frysinger <vapier@gentoo.org>